### PR TITLE
Bump to STEPS version 5.0.1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ updated to publish the corresponding Docker image.
 	 services:
 	   lab:
 	-    image: cnsoist/steps:3.1
-	+    image: cnsoist/steps:3.2
+	+    image: cnsoist/steps:5.0.1
 	     build: recipe
 	     hostname: $HOST
 	     ports:
@@ -105,7 +105,7 @@ updated to publish the corresponding Docker image.
     ``` {.bash}
     $ git checkout master
     $ git pull origin
-    $ git tag 3.2
+    $ git tag 5.0.1
     $ git push --tags
     ```
 
@@ -153,7 +153,7 @@ The following command will:
 docker buildx build --platform linux/amd64,linux/arm64 --build-arg STEPS_UT=false -t cnsoist/steps:latest --push recipe
 ```
 
-To create tag alias `5.0.0` on Docker Hub:
+To create tag alias `5.0.1` on Docker Hub:
 ```
-docker buildx imagetools create -t cnsoist/steps:5.0.0 cnsoist/steps:latest
+docker buildx imagetools create -t cnsoist/steps:5.0.1 cnsoist/steps:latest
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ STEPS Python module.
 ```bash
 $ git clone https://github.com/CNS-OIST/STEPS_Docker
 $ cd STEPS_Docker
-$ echo "DUID=$(($(id -u)+1))\nDGID=$(id -g)\nHOST=$(hostname)" > .env
+$ echo -e "USER_ID=$(id -u)\nGROUP_ID=$(id -g)\nHOST=$(hostname)" > .env
 $ docker-compose build
 $ docker-compose up
 Creating network "stepsdocker_default" with the default driver
@@ -64,7 +64,7 @@ By default, this repository use the latest stable of STEPS but you can choose to
 
 ```bash
 $ git checkout TAG
-$ echo "DUID=$(($(id -u)+1))\nDGID=$(id -g)\nHOST=$(hostname)" > .env
+$ echo -e "USER_ID=$(id -u)\nGROUP_ID=$(id -g)\nHOST=$(hostname)" > .env
 $ docker-compose up lab
 ```
 
@@ -105,7 +105,7 @@ you to import your notebooks. In this case, you can either:
 
 ## Windows support
 
-This Docker image can be run with _Docker Desktop for Windows_. Instructions in the *Getting Started* section above are a bit different though. Instead of executing command `echo "DUID=$(($(id -u)+1))\nDGID=$(id -g)\nHOST=$(hostname)" > .env`, update the `docker-compose.yaml` file as follow:
+This Docker image can be run with _Docker Desktop for Windows_. Instructions in the *Getting Started* section above are a bit different though. Instead of executing command `echo "DUID=$(id -u)\nDGID=$(id -g)\nHOST=$(hostname)" > .env`, update the `docker-compose.yaml` file as follow:
 
 * **hostname**: hardcode the machine name
 * **USER_LOGIN**: hardcode your user name
@@ -122,7 +122,7 @@ index 528e993..64dcca9 100644
 +++ b/docker-compose.yml
 @@ -3,15 +3,15 @@ services:
    lab:
-     image: cnsoist/steps:3.4
+     image: cnsoist/steps:5.0.1
      build: recipe
 -    hostname: $HOST
 +    hostname: my-windows10-machine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,12 @@
 version: '2.2'
 services:
   lab:
-    image: cnsoist/steps:5.0.0_beta
+    image: cnsoist/steps:5.0.1
     build: recipe
     hostname: $HOST
     ports:
     - "8888:8888"
-    environment:
-    - USER_LOGIN=$USER
-    - USER_ID=$DUID
-    - GROUP_ID=$DGID
+    env_file: .env
     entrypoint: [/usr/bin/entrypoint]
     command:
     - jupyter

--- a/recipe/Dockerfile
+++ b/recipe/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get --yes -qq update \
                       libglu1 \
                       libgsl-dev \
                       libmetis-dev \
+                      librdmacm-dev \
                       libxcursor1 \
                       libxft2 \
                       libxinerama1 \
@@ -36,14 +37,14 @@ RUN apt-get --yes -qq update \
  && apt-get --yes -qq clean \
  && rm -rf /var/lib/apt/lists/*
 
-ENV GOSU_VERSION 1.11
+ENV GOSU_VERSION 1.17
 RUN dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
  && chmod +x /usr/local/bin/gosu \
 # verify that the binary works
  && gosu nobody true
 
-ARG MINICONDA_VERSION=3-py39_23.3.1-0
+ARG MINICONDA_VERSION=3-py312_24.1.2-0
 RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
  && dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')" \
  && minicondaArch="$(case $dpkgArch in amd64) echo x86_64 ;; arm64) echo aarch64 ;; *) echo Unexpected arch: $dpkgArch; false ;; esac)" \
@@ -65,7 +66,7 @@ RUN echo 'export PATH=/opt/conda/bin:$PATH' > /etc/profile.d/conda.sh \
 ENV PATH "/opt/conda/bin:$PATH"
 ENV CMAKE_PREFIX_PATH=/opt/conda
 
-ARG GMSH_VERSION=4.11.1
+ARG GMSH_VERSION=4.12.2
 RUN wget https://gmsh.info/src/gmsh-${GMSH_VERSION}-source.tgz \
  && tar zxf gmsh-${GMSH_VERSION}-source.tgz \
  && cd gmsh-${GMSH_VERSION}-source \
@@ -100,14 +101,15 @@ RUN if [ "x$BUILD_OMEGA_H" = xtrue ] ; then ( \
    ) fi
 
 ADD overlap-arm64.patch /var/src/
-ARG STEPS_VERSION=5.0.0_beta
+ARG STEPS_VERSION=5.0.1
 ARG STEPS_UT=false
 ARG STEPS_UT_KEEP_GOING=true
 ENV CTEST_OUTPUT_ON_FAILURE=1
 ARG STEPS_REPOSITORY=STEPS
 ARG STEPS_ACCESS_TOKEN=
 ARG STEPS_NATIVE_ARCH=False
-RUN git clone --recursive \
+RUN chmod +x /root \
+ && git clone --recursive \
     https://${STEPS_ACCESS_TOKEN}github.com/CNS-OIST/${STEPS_REPOSITORY}.git /var/src/STEPS \
  && cd /var/src/STEPS \
  && git checkout "$STEPS_VERSION" \
@@ -115,13 +117,13 @@ RUN git clone --recursive \
  && patch -p1 < /var/src/overlap-arm64.patch \
  && mkdir build \
  && cd build \
+ && python -c "import os,sysconfig; os.makedirs(sysconfig.get_path('platlib', f'{os.name}_user'), exist_ok=True)" \
  && cmake \
       -DTARGET_NATIVE_ARCH:BOOL="$STEPS_NATIVE_ARCH" \
       -DUSE_BUNDLE_SUNDIALS:BOOL=TRUE \
       -DUSE_BUNDLE_OMEGA_H:BOOL=FALSE \
       -DUSE_MPI:BOOL=ON \
       -DUSE_DISTRIBUTED_MESH:BOOL=TRUE \
-      -DPYTHON_LIBRARY:FILEPATH=/opt/conda/lib/libpython3.9.so \
       .. \
  && make -j 4 all \
  && ([ "$STEPS_UT" = false ] || \
@@ -136,9 +138,6 @@ RUN git clone --recursive \
 RUN git clone https://github.com/CNS-OIST/STEPS_Example.git /var/src/STEPS_Example \
  && mv /var/src/STEPS_Example/user_manual/source /var/src/user_manual \
  && rm -rf /var/src/STEPS_Example
-
-RUN echo "/usr/lib/python3.8/config-3.8-x86_64-linux-gnu" >> /etc/ld.so.conf.d/python-lib.conf \
-  && ldconfig
 
 ARG EXAMPLE_NOTEBOOKS_TO_REBUILD="diffusion_boundary diffusion getting_started ip3 memb_pot sbml_importer surface_diffusion_boundary surface_diffusion well_mixed"
 # https://nbconvert.readthedocs.io/en/latest/usage.html#convert-notebook


### PR DESCRIPTION
* Fix regression in the permissions of the user manual mounted inside the container
* Bump miniconda to Python 3.10
* Bump Gmsh to 4.12.2